### PR TITLE
Acknowledge existence of `Object.setPrototypeOf`

### DIFF
--- a/exercises/060_object_create/problem.md
+++ b/exercises/060_object_create/problem.md
@@ -32,7 +32,9 @@ var zack = Object.create(alien);
 Object.getPrototypeOf(zack); //=> alien
 ```
 
-There is no such thing as `Object.setPrototype`.
+### `Object.setPrototypeOf`
+
+Newer versions of JavaScript (ES2015) also provide `Object.setPrototypeOf(object, prototype)` as an "official" alternative to changing `__proto__`. However, please keep in mind that changing the prototype on runtime is a very slow operation. It's always better to define the prototype *before* the object is created, e.g. by using `Object.create()`. 
 
 Challenge
 ---------


### PR DESCRIPTION
I felt that saying *"There is no such thing as `Object.setPrototype`"* is not right :grin:.

Imho it would even be better to change all examples from `__proto__` to `Object.setPrototypeOf()`. I've read the discussion at #6 and I do understand your arguments. But explaining language concepts by using deprecated features does not feel right.